### PR TITLE
added possiblity to have groups as Objects

### DIFF
--- a/polymer-sortablejs.html
+++ b/polymer-sortablejs.html
@@ -12,7 +12,7 @@
     is: "sortable-js",
 
     properties: {
-      group             : { type: String, value: function() { return Math.random(); }, observer: "groupChanged" },
+      group             : { type: Object, value: () => {return {name: Math.random()};}, observer: "groupChanged" },
       sort              : { type: Boolean, value: true, observer: "sortChanged" },
       disabled          : { type: Boolean, value: false, observer: "disabledChanged" },
       store             : { type: Object, value: null, observer: "storeChanged" },
@@ -153,7 +153,12 @@
       }
     },
 
-    groupChanged             : function(value) { this.sortable && this.sortable.option("group", value); },
+    groupChanged             : function(value) { 
+      if(typeof(value) === 'string') {
+        return this.set('group', {name: value});
+      }
+      this.sortable && this.sortable.option("group",  value );
+    },
     sortChanged              : function(value) { this.sortable && this.sortable.option("sort", value); },
     disabledChanged          : function(value) { this.sortable && this.sortable.option("disabled", value); },
     storeChanged             : function(value) { this.sortable && this.sortable.option("store", value); },


### PR DESCRIPTION
Because we want to be able to specify groups declaratively: 

```html

<sortable-js  group="[[group]]"></sortablejs>

...

    Polymer({
      is: 'sortable-drop-panel',
      properties: {
        group: {
          type: Object,
          value: function() {
            return {
              name: 'groupBin',
              put: ['groupTarget']
            };
          }
        }
...
```
